### PR TITLE
Add price service mocks and middleware tests

### DIFF
--- a/test/errorHandler.test.js
+++ b/test/errorHandler.test.js
@@ -1,0 +1,49 @@
+const errorHandler = require('../src/middleware/errorHandler');
+
+describe('errorHandler middleware', () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+
+  beforeEach(() => {
+    res.status.mockClear();
+    res.json.mockClear();
+  });
+
+  it('handles axios errors', () => {
+    const err = {
+      response: { status: 404, data: { message: 'Not found' } },
+      message: 'axios error',
+    };
+    errorHandler(err, { query: { provider: 'test' } }, res, () => {});
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'External API error',
+      message: 'Not found',
+      provider: 'test',
+    });
+  });
+
+  it('handles network errors', () => {
+    const err = { request: {}, message: 'network error' };
+    errorHandler(err, { query: { provider: 'test' } }, res, () => {});
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Network error',
+      message: 'Unable to connect to external service',
+      provider: 'test',
+    });
+  });
+
+  it('handles application errors', () => {
+    const err = { message: 'boom' };
+    errorHandler(err, { query: {} }, res, () => {});
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Internal server error',
+      message: 'boom',
+      provider: 'unknown',
+    });
+  });
+});

--- a/test/price.test.js
+++ b/test/price.test.js
@@ -1,3 +1,53 @@
+const mockGetBulkPrices = jest.fn(async symbols => {
+  await Promise.resolve();
+  return {
+    results: symbols.reduce((acc, symbol) => {
+      acc[symbol] = {
+        success: true,
+        price: 100,
+        symbol,
+        provider: 'mock',
+        timestamp: new Date().toISOString(),
+      };
+      return acc;
+    }, {}),
+    errors: [],
+    totalRequested: symbols.length,
+    fromCache: 0,
+    fromProviders: symbols.length,
+    failed: 0,
+    timestamp: new Date().toISOString(),
+  };
+});
+
+const mockGetPrice = jest.fn(async symbol => {
+  await Promise.resolve();
+  if (symbol === 'unsupported-token-xyz') {
+    throw new Error('Token unsupported');
+  }
+  return {
+    success: true,
+    price: 100,
+    symbol,
+    provider: 'mock',
+    timestamp: new Date().toISOString(),
+  };
+});
+
+jest.mock('../src/services/priceService', () => {
+  return jest.fn().mockImplementation(() => ({
+    getBulkPrices: mockGetBulkPrices,
+    getPrice: mockGetPrice,
+    getSupportedProviders: jest.fn(() => ['mock']),
+    getStatus: jest.fn(() => ({
+      providers: { mock: { available: true } },
+      rateLimits: {},
+      cache: { size: 0, entries: [] },
+    })),
+    clearCache: jest.fn(),
+  }));
+});
+
 const request = require('supertest');
 const app = require('../src/app');
 const intentRoutes = require('../src/routes/intents');

--- a/test/priceService.test.js
+++ b/test/priceService.test.js
@@ -1,0 +1,59 @@
+jest.mock('../src/services/priceProviders/coinmarketcap', () => {
+  return jest.fn().mockImplementation(() => ({
+    getPrice: jest.fn(async symbol => {
+      await Promise.resolve();
+      return {
+        success: true,
+        price: 100,
+        symbol,
+        provider: 'coinmarketcap',
+        timestamp: new Date().toISOString(),
+      };
+    }),
+    getBulkPrices: jest.fn(),
+    isAvailable: jest.fn(() => true),
+    getStatus: jest.fn(() => ({ name: 'coinmarketcap', available: true })),
+  }));
+});
+
+jest.mock('../src/services/priceProviders/coingecko', () => {
+  return jest.fn().mockImplementation(() => ({
+    getPrice: jest.fn(async symbol => {
+      await Promise.resolve();
+      return {
+        success: true,
+        price: 101,
+        symbol,
+        provider: 'coingecko',
+        timestamp: new Date().toISOString(),
+      };
+    }),
+    getBulkPrices: jest.fn(),
+    isAvailable: jest.fn(() => true),
+    getStatus: jest.fn(() => ({ name: 'coingecko', available: true })),
+  }));
+});
+
+const PriceService = require('../src/services/priceService');
+
+describe('PriceService caching', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns cached price on subsequent calls', async () => {
+    const service = new PriceService();
+    const first = await service.getPrice('btc');
+    const second = await service.getPrice('btc');
+    expect(first.fromCache).toBe(false);
+    expect(second.fromCache).toBe(true);
+    expect(service.providers.coinmarketcap.getPrice).toHaveBeenCalledTimes(1);
+  });
+
+  it('bypasses cache when useCache is false', async () => {
+    const service = new PriceService();
+    await service.getPrice('eth');
+    await service.getPrice('eth', { useCache: false });
+    expect(service.providers.coinmarketcap.getPrice).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/swapErrorClassifier.test.js
+++ b/test/swapErrorClassifier.test.js
@@ -1,0 +1,103 @@
+const {
+  SwapErrorClassifier,
+  ERROR_CATEGORIES,
+  PROVIDER_STATES,
+  SSE_EVENT_TYPES,
+} = require('../src/utils/SwapErrorClassifier');
+
+describe('SwapErrorClassifier', () => {
+  describe('classifyError', () => {
+    it('should classify network errors', () => {
+      const result = SwapErrorClassifier.classifyError('network timeout', {
+        tokenSymbol: 'BTC',
+      });
+      expect(result.category).toBe(ERROR_CATEGORIES.NETWORK_ERROR);
+      expect(result.providerState).toBe(PROVIDER_STATES.TIMEOUT);
+      expect(result.userFriendlyMessage).toMatch(/Network error/);
+    });
+
+    it('should classify validation errors', () => {
+      const result = SwapErrorClassifier.classifyError('validation failed', {
+        tokenSymbol: 'ETH',
+      });
+      expect(result.category).toBe(ERROR_CATEGORIES.VALIDATION_ERROR);
+      expect(result.providerState).toBe(PROVIDER_STATES.FAILED);
+    });
+
+    it('should classify data extraction errors', () => {
+      const result = SwapErrorClassifier.classifyError('some error', {
+        tokenSymbol: 'USDC',
+        swapQuote: {},
+      });
+      expect(result.category).toBe(ERROR_CATEGORIES.DATA_EXTRACTION_ERROR);
+    });
+
+    it('should classify quote failures', () => {
+      const result = SwapErrorClassifier.classifyError('no route', {
+        tokenSymbol: 'DAI',
+        swapQuote: { provider: 'failed' },
+      });
+      expect(result.category).toBe(ERROR_CATEGORIES.QUOTE_FAILED);
+      expect(result.providerState).toBe(PROVIDER_STATES.FAILED);
+    });
+
+    it('should classify processing errors by default', () => {
+      const result = SwapErrorClassifier.classifyError('other error', {
+        tokenSymbol: 'MKR',
+        swapQuote: { provider: 'uniswap' },
+      });
+      expect(result.category).toBe(ERROR_CATEGORIES.PROCESSING_ERROR);
+      expect(result.providerState).toBe(PROVIDER_STATES.ERROR);
+    });
+  });
+
+  describe('createFallbackData', () => {
+    it('should create standardized fallback data', () => {
+      const classification = {
+        category: ERROR_CATEGORIES.NETWORK_ERROR,
+        providerState: PROVIDER_STATES.TIMEOUT,
+        errorMessage: 'timeout',
+        userFriendlyMessage: 'Network error',
+      };
+      const data = SwapErrorClassifier.createFallbackData(classification, {
+        inputValueUSD: 100,
+      });
+      expect(data.provider).toBe(PROVIDER_STATES.TIMEOUT);
+      expect(data.tradingLoss.netLossUSD).toBe(100);
+      expect(data.errorCategory).toBe(ERROR_CATEGORIES.NETWORK_ERROR);
+      expect(data.success).toBe(false);
+    });
+  });
+
+  it('getSSEEventType should always return token_failed', () => {
+    expect(SwapErrorClassifier.getSSEEventType({})).toBe(
+      SSE_EVENT_TYPES.TOKEN_FAILED
+    );
+  });
+
+  it('createSSEErrorEvent should build event with fallback data', () => {
+    const token = { symbol: 'BTC', address: '0xbtc', amount: 1, price: 10000 };
+    const event = SwapErrorClassifier.createSSEErrorEvent(
+      token,
+      'network down',
+      0,
+      { processedTokens: 0, totalTokens: 2 }
+    );
+    expect(event.type).toBe(SSE_EVENT_TYPES.TOKEN_FAILED);
+    expect(event.tokenSymbol).toBe('BTC');
+    expect(event.progress).toBeCloseTo(0.5);
+    expect(event.tradingLoss.inputValueUSD).toBe(10000);
+  });
+
+  describe('isSwapSuccessful', () => {
+    it('should detect successful swaps', () => {
+      const swapResult = { success: true, swapQuote: { provider: 'ok' } };
+      expect(SwapErrorClassifier.isSwapSuccessful(swapResult)).toBe(true);
+    });
+
+    it('should detect failed swaps', () => {
+      const swapResult = { success: false, swapQuote: { provider: 'failed' } };
+      expect(SwapErrorClassifier.isSwapSuccessful(swapResult)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- mock PriceService in price endpoint tests to avoid external API failures
- add caching unit tests for PriceService
- cover errorHandler middleware to satisfy coverage thresholds

## Testing
- `npm run lint`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68956a2b12848325af1c9c9bea54b37b