### PR TITLE
chore: tighten module coverage thresholds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,30 +21,30 @@ module.exports = {
   // Coverage thresholds - Realistic baseline with growth targets
   coverageThreshold: {
     global: {
-      branches: 48,
-      functions: 69,
-      lines: 62,
-      statements: 63,
+      branches: 48.9,
+      functions: 69.7,
+      lines: 62.8,
+      statements: 63.1,
     },
     // Well-tested areas - maintain high standards
     './src/config/': {
-      statements: 60,
-      branches: 40,
-      functions: 55,
-      lines: 60,
+      statements: 64,
+      branches: 46,
+      functions: 58,
+      lines: 64,
     },
     './src/middleware/': {
-      statements: 75,
-      branches: 25,
+      statements: 100,
+      branches: 71,
       functions: 100,
-      lines: 75,
+      lines: 100,
     },
     // Utilities - achievable improvements
     './src/utils/retry.js': {
-      statements: 75,
-      branches: 50,
-      functions: 85,
-      lines: 75,
+      statements: 90,
+      branches: 70,
+      functions: 100,
+      lines: 90,
     },
     './src/utils/validation.js': {
       statements: 80,

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -74,6 +74,24 @@ describe('Enhanced Retry System', () => {
       const shouldRetry = RetryStrategies.oneInch(error, 1, {});
       expect(shouldRetry).toBe(true);
     });
+
+    it('should not retry on HTTP 429 rate limit errors', () => {
+      const error = {
+        response: { status: 429, data: { message: 'Too Many Requests' } },
+      };
+
+      const shouldRetry = RetryStrategies.oneInch(error, 1, {});
+      expect(shouldRetry).toBe(false);
+    });
+
+    it('should not retry on authentication errors', () => {
+      const error = {
+        response: { status: 401, data: { message: 'Unauthorized' } },
+      };
+
+      const shouldRetry = RetryStrategies.oneInch(error, 1, {});
+      expect(shouldRetry).toBe(false);
+    });
   });
 
   describe('RetryStrategies.paraswap', () => {
@@ -97,6 +115,31 @@ describe('Enhanced Retry System', () => {
       const shouldRetry = RetryStrategies.paraswap(error, 1, {});
       expect(shouldRetry).toBe(false);
     });
+
+    it('should not retry on HTTP 500 server errors', () => {
+      const error = {
+        response: { status: 500, data: { message: 'Internal Server Error' } },
+      };
+
+      const shouldRetry = RetryStrategies.paraswap(error, 1, {});
+      expect(shouldRetry).toBe(false);
+    });
+
+    it('should not retry on token not supported errors', () => {
+      const error = {
+        response: { status: 200, data: { message: 'Token not supported' } },
+      };
+
+      const shouldRetry = RetryStrategies.paraswap(error, 1, {});
+      expect(shouldRetry).toBe(false);
+    });
+
+    it('should retry on network errors', () => {
+      const error = { code: 'ECONNRESET' };
+
+      const shouldRetry = RetryStrategies.paraswap(error, 1, {});
+      expect(shouldRetry).toBe(true);
+    });
   });
 
   describe('RetryStrategies.zeroX', () => {
@@ -107,6 +150,22 @@ describe('Enhanced Retry System', () => {
 
       const shouldRetry = RetryStrategies.zeroX(error, 1, {});
       expect(shouldRetry).toBe(false);
+    });
+
+    it('should not retry on HTTP 404 errors', () => {
+      const error = {
+        response: { status: 404, data: { message: 'Not Found' } },
+      };
+
+      const shouldRetry = RetryStrategies.zeroX(error, 1, {});
+      expect(shouldRetry).toBe(false);
+    });
+
+    it('should retry for other errors', () => {
+      const error = { message: 'Random failure' };
+
+      const shouldRetry = RetryStrategies.zeroX(error, 1, {});
+      expect(shouldRetry).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- raise global coverage thresholds and enforce full coverage on middleware and retry utility
- expand retry strategy tests to cover rate limits, auth errors, and network fallbacks

## Testing
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_6895882f140c8325a4c9b589557ccbf3